### PR TITLE
Feat : 중복 코드 제거를 위해 APIResponse 클래스에 변환 메소드 추가 #25

### DIFF
--- a/src/main/java/com/seveneleven/devlens/global/response/APIResponse.java
+++ b/src/main/java/com/seveneleven/devlens/global/response/APIResponse.java
@@ -3,6 +3,7 @@ package com.seveneleven.devlens.global.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.springframework.http.ResponseEntity;
 
 @Getter
 @ToString
@@ -39,5 +40,9 @@ public class APIResponse<T> {
 
     public static <T> APIResponse<T> create(int code, String message, T data) {
         return new APIResponse<>(code, message, data);
+    }
+
+    public ResponseEntity<APIResponse<T>> toResponseEntity() {
+        return ResponseEntity.status(code).body(this);
     }
 }

--- a/src/main/java/com/seveneleven/devlens/global/response/APIResponse.java
+++ b/src/main/java/com/seveneleven/devlens/global/response/APIResponse.java
@@ -3,6 +3,7 @@ package com.seveneleven.devlens.global.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 @Getter
@@ -43,6 +44,6 @@ public class APIResponse<T> {
     }
 
     public ResponseEntity<APIResponse<T>> toResponseEntity() {
-        return ResponseEntity.status(code).body(this);
+        return ResponseEntity.status(HttpStatus.valueOf(code)).body(this);
     }
 }


### PR DESCRIPTION
**바로 MERGE하지 마세요! 검토 후 MERGE해야합니다!**

## ✅ 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가

<br />

## 🏆 구현 목표 
ResponseEntity 변환 메소드가 중복됨, 하나의 클래스에 변환 메소드 만들거임

<br />

## 📋 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. ApiResponse에 응답 엔티티 반환 메소드 추가


<br />

## 🔍 테스트 방법 (변경 사항을 확인하기 위한 테스트 방법을 기술합니다.)
1. Postman으로 API 호출 테스트

<br />

