### PR TITLE
Chore : 모듈 메인클래스 이름 변경

### DIFF
--- a/Admin/src/main/java/com/seveneleven/AdminApplication.java
+++ b/Admin/src/main/java/com/seveneleven/AdminApplication.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
-public class Main {
+public class AdminApplication {
     public static void main(String[] args) {
         SpringApplication.run(Main.class, args);
     }

--- a/Admin/src/main/java/com/seveneleven/AdminApplication.java
+++ b/Admin/src/main/java/com/seveneleven/AdminApplication.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 public class AdminApplication {
     public static void main(String[] args) {
-        SpringApplication.run(Main.class, args);
+        SpringApplication.run(AdminApplication.class, args);
     }
 }

--- a/Admin/src/main/resources/application.properties
+++ b/Admin/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=DevLens-Main
+spring.application.name=DevLens-AdminApplication
 
 spring.config.import=optional:file:.env[.properties]
 

--- a/Main/src/main/java/com/seveneleven/MainApplication.java
+++ b/Main/src/main/java/com/seveneleven/MainApplication.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
-public class Main {
+public class MainApplication {
     public static void main(String[] args) {
         SpringApplication.run(Main.class, args);
     }

--- a/Main/src/main/java/com/seveneleven/MainApplication.java
+++ b/Main/src/main/java/com/seveneleven/MainApplication.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 public class MainApplication {
     public static void main(String[] args) {
-        SpringApplication.run(Main.class, args);
+        SpringApplication.run(MainApplication.class, args);
     }
 }

--- a/Main/src/main/resources/application.properties
+++ b/Main/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=DevLens-Main
+spring.application.name=DevLens-MainApplication
 
 spring.config.import=optional:file:.env[.properties]
 


### PR DESCRIPTION
- 모듈의 실행 클래스가 이름이 전부 `Main`이라서 혼동됨

**바로 MERGE하지 마세요! 검토 후 MERGE해야합니다!**

## ✅ 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영 수정
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정
- [ ] 브랜치 최신화

<br />

## 🏆 구현 목표 
- 